### PR TITLE
Add v4 unsupported

### DIFF
--- a/libs/hbb_common/protos/rendezvous.proto
+++ b/libs/hbb_common/protos/rendezvous.proto
@@ -82,6 +82,7 @@ message PunchHoleResponse {
     LICENSE_MISMATCH = 3;
     LICENSE_OVERUSE = 4;
     IPV6_UNSUPPORTED = 5;
+    IPV4_UNSUPPORTED = 6;
   }
   Failure failure = 3;
   string relay_server = 4;

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -778,6 +778,14 @@ impl RendezvousServer {
                 });
                 return Ok((msg_out, None));
             }
+            if addr.is_ipv4() && peer_addr.is_ipv6() {
+                let mut msg_out = RendezvousMessage::new();
+                msg_out.set_punch_hole_response(PunchHoleResponse {
+                    failure: punch_hole_response::Failure::IPV4_UNSUPPORTED.into(),
+                    ..Default::default()
+                });
+                return Ok((msg_out, None));
+            }
             let mut msg_out = RendezvousMessage::new();
             let peer_is_lan = self.is_lan(peer_addr);
             let is_lan = self.is_lan(addr);


### PR DESCRIPTION
As mentioned in https://github.com/rustdesk/rustdesk/issues/152#issuecomment-1194226072 in issue, provide feedback that IPV4 in an IPV6 only environment does not support